### PR TITLE
[cstor#55] Implement protocol version so that we can have mixed clust…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,18 @@ sudo: required
 
     
 before_install:
-#sudo apt-get -qq update
+    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    - sudo apt-get update -qq
+    - sudo apt-get install --yes -qq gcc-6 g++-6
     - sudo apt-get install --yes -qq build-essential autoconf libtool gawk alien fakeroot linux-headers-$(uname -r) libaio-dev
     - sudo apt-get install --yes -qq zlib1g-dev uuid-dev libattr1-dev libblkid-dev libselinux-dev libudev-dev libssl-dev
     - sudo apt-get install --yes -qq lcov libjemalloc-dev
-#packages for tests
+    # packages for tests
     - sudo apt-get install --yes -qq parted lsscsi ksh attr acl nfs-kernel-server fio
     - sudo apt-get install --yes -qq libgtest-dev cmake
+    # use gcc-6 by default
+    - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
+    - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++
 
 
 install:

--- a/cstor-prerequisites
+++ b/cstor-prerequisites
@@ -1,11 +1,15 @@
 #!/bin/sh
 set -e
 
-#sudo apt-get -qq update
-  sudo apt-get install --yes -qq build-essential autoconf libtool gawk alien fakeroot linux-headers-$(uname -r) libaio-dev
-  sudo apt-get install --yes -qq zlib1g-dev uuid-dev libattr1-dev libblkid-dev libselinux-dev libudev-dev libssl-dev
-  sudo apt-get install --yes -qq lcov libjemalloc-dev
+sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+sudo apt-get update -qq
+sudo apt-get install --yes -qq gcc-6 g++-6
+sudo apt-get install --yes -qq build-essential autoconf libtool gawk alien fakeroot linux-headers-$(uname -r) libaio-dev
+sudo apt-get install --yes -qq zlib1g-dev uuid-dev libattr1-dev libblkid-dev libselinux-dev libudev-dev libssl-dev
+sudo apt-get install --yes -qq lcov libjemalloc-dev
 #packages for tests
-  sudo apt-get install --yes -qq parted lsscsi ksh attr acl nfs-kernel-server fio
-  sudo apt-get install --yes -qq libgtest-dev cmake
+sudo apt-get install --yes -qq parted lsscsi ksh attr acl nfs-kernel-server fio
+sudo apt-get install --yes -qq libgtest-dev cmake
+sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
+sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++
 


### PR DESCRIPTION
…er during upgrade

There are new C++ tests in uzfs repo, introduced on behalf of the
ticket above, which require gcc version 6.