### PR TITLE
Cstor base test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ install:
     - sudo make
     - sudo cp *.a /usr/lib
     - popd
-    - make cstor-base-image
-    - make cstor-pool-image 
+    - make all
 
 #before_script:
 #    - make cstyle;

--- a/Dockerfile.BaseTestImage
+++ b/Dockerfile.BaseTestImage
@@ -1,0 +1,23 @@
+#
+# This Dockerfile copies base image cstor binaries and 
+# libraries to shared location.
+#
+
+FROM openebs/cstor-base:ci
+
+COPY /usr/local/bin/zrepl /tmp/
+COPY /usr/local/bin/zpool /tmp/
+COPY /usr/local/bin/zfs /tmp/
+
+COPY /usr/lib/libzfs*.so* /tmp/
+COPY /usr/lib/libnvpair*.so* /tmp/
+COPY /usr/lib/libuutil*.so* /tmp/
+COPY /usr/lib/libzpool*.so* /tmp/
+
+ARG BUILD_DATE
+LABEL org.label-schema.name="cstor"
+LABEL org.label-schema.description="OpenEBS cstor"
+LABEL org.label-schema.url="http://www.openebs.io/"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE

--- a/Dockerfile.BaseTestImage
+++ b/Dockerfile.BaseTestImage
@@ -5,14 +5,9 @@
 
 FROM openebs/cstor-base:ci
 
-COPY /usr/local/bin/zrepl /tmp/
-COPY /usr/local/bin/zpool /tmp/
-COPY /usr/local/bin/zfs /tmp/
+COPY entrypoint-basetest.sh /usr/local/bin/
 
-COPY /usr/lib/libzfs*.so* /tmp/
-COPY /usr/lib/libnvpair*.so* /tmp/
-COPY /usr/lib/libuutil*.so* /tmp/
-COPY /usr/lib/libzpool*.so* /tmp/
+RUN chmod +x /usr/local/bin/entrypoint-basetest.sh
 
 ARG BUILD_DATE
 LABEL org.label-schema.name="cstor"
@@ -21,3 +16,6 @@ LABEL org.label-schema.url="http://www.openebs.io/"
 LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$BUILD_DATE
+
+ENTRYPOINT entrypoint-basetest.sh
+EXPOSE 7678

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -28,7 +28,7 @@ cstor-basetest-image:
 	@echo "--> cstor-baseshared-image         "
 	@echo "----------------------------"
 	@sudo docker build -f Dockerfile.BaseTestImage -t openebs/cstor-test:ci --build-arg BUILD_DATE=${BUILD_DATE} .
-	@sh push-testimage
+	@sh push-basetestimage
 
 prerequisites:
 	@echo "----------------------------"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,7 +1,7 @@
 # Specify the date o build
 BUILD_DATE = $(shell date +'%Y%m%d%H%M%S')
 
-all: cstor-base-image
+all: cstor-base-image cstor-basetest-image cstor-pool-image
 
 cstor-build:
 	@echo "----------------------------"
@@ -22,6 +22,13 @@ cstor-pool-image:
 	@echo "----------------------------"
 	@sudo docker build -f Dockerfile.Poolimage -t openebs/cstor-pool:ci --build-arg BUILD_DATE=${BUILD_DATE} .
 	@sh push-poolimage
+
+cstor-basetest-image:
+	@echo "----------------------------"
+	@echo "--> cstor-baseshared-image         "
+	@echo "----------------------------"
+	@sudo docker build -f Dockerfile.BaseTestImage -t openebs/cstor-test:ci --build-arg BUILD_DATE=${BUILD_DATE} .
+	@sh push-testimage
 
 prerequisites:
 	@echo "----------------------------"

--- a/entrypoint-basetest.sh
+++ b/entrypoint-basetest.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -ex
+
+export SHARED_LOC=/tmp/
+
+cp /usr/local/bin/zrepl $SHARED_LOC
+cp /usr/local/bin/zpool $SHARED_LOC
+cp /usr/local/bin/zfs $SHARED_LOC
+
+cp /usr/lib/libzfs*.so* $SHARED_LOC
+cp /usr/lib/libnvpair*.so* $SHARED_LOC
+cp /usr/lib/libuutil*.so* $SHARED_LOC
+cp /usr/lib/libzpool*.so* $SHARED_LOC

--- a/push-basetestimage
+++ b/push-basetestimage
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+IMAGEID=$( sudo docker images -q openebs/cstor-test:ci )
+
+if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
+then 
+  sudo docker login -u "${DNAME}" -p "${DPASS}";
+  # Push image to docker hub
+  sudo docker push openebs/cstor-test:ci ;
+  if [ ! -z "${TRAVIS_TAG}" ] ; 
+  then
+    # Push with different tags if tagged as a release
+    # When github is tagged with a release, then Travis will 
+    # set the release tag in env TRAVIS_TAG
+    sudo docker tag ${IMAGEID} openebs/cstor-test:${TRAVIS_TAG}
+    sudo docker push openebs/cstor-test:${TRAVIS_TAG}; 
+    sudo docker tag ${IMAGEID} openebs/cstor-test:latest
+    sudo docker push openebs/cstor-test:latest; 
+  fi;
+else
+  echo "No docker credentials provided. Skip uploading openebs/cstor-test:ci to docker hub"; 
+fi;


### PR DESCRIPTION
What happened:
Unit testing cstor-kubernetes interface requires cstor binaries and libraries.

What you expected to happen:
A new image that copies the required cstor binaries and libraries from /usr/local/bin and /usr/lib to the shared location, which can be picked by the host for unit testing.

How to reproduce it (as minimally and precisely as possible):
The image openebs/cstor-test:ci image is created.