### PR TITLE
Added cstor-istgt-image target into cstor makefile and updated gitign…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/spl
+/zfs
+/istgt

--- a/Dockerfile.Istgtimage
+++ b/Dockerfile.Istgtimage
@@ -2,10 +2,10 @@
 # This Dockerfile builds cstor istgt container running istgt from istgt base image
 #
 
-FROM ubuntu:16.04
-RUN apt-get update
+FROM ubuntu:18.04
+RUN apt-get update; exit 0
 RUN apt-get -y install rsyslog
-RUN apt-get -y install libssl-dev
+RUN apt-get -y install libssl-dev libssl1.1
 RUN apt -y install apt-file && apt-file update
 
 RUN mkdir -p /usr/local/etc/istgt

--- a/Dockerfile.Istgtimage
+++ b/Dockerfile.Istgtimage
@@ -1,0 +1,29 @@
+#
+# This Dockerfile builds cstor istgt container running istgt from istgt base image
+#
+
+FROM openebs/istgt_base:latest
+
+RUN mkdir -p /usr/local/etc/istgt
+RUN mkdir -p /tmp/cstor
+COPY istgt/src/istgt istgt/src/istgtcontrol /usr/local/bin/
+COPY istgt/src/istgt.conf istgt/src/istgtcontrol.conf /usr/local/etc/istgt/
+COPY istgt/src/istgt.conf istgt/src/istgtcontrol.conf /tmp/cstor/
+RUN touch /usr/local/etc/istgt/auth.conf
+RUN touch /usr/local/etc/istgt/logfile
+
+COPY istgt/src/init.sh /
+RUN chmod +x /init.sh
+COPY entrypoint-istgtimage.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint-istgtimage.sh
+
+ARG BUILD_DATE
+LABEL org.label-schema.name="cstor"
+LABEL org.label-schema.description="OpenEBS cstor"
+LABEL org.label-schema.url="http://www.openebs.io/"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+
+ENTRYPOINT entrypoint-istgtimage.sh
+EXPOSE 3260 

--- a/Dockerfile.Istgtimage
+++ b/Dockerfile.Istgtimage
@@ -22,4 +22,4 @@ LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$BUILD_DATE
 
 ENTRYPOINT entrypoint-istgtimage.sh
-EXPOSE 3260 
+EXPOSE 3260 6060

--- a/Dockerfile.Istgtimage
+++ b/Dockerfile.Istgtimage
@@ -2,7 +2,11 @@
 # This Dockerfile builds cstor istgt container running istgt from istgt base image
 #
 
-FROM openebs/istgt_base:latest
+FROM ubuntu:16.04
+RUN apt-get update
+RUN apt-get -y install rsyslog
+RUN apt-get -y install libssl-dev
+RUN apt -y install apt-file && apt-file update
 
 RUN mkdir -p /usr/local/etc/istgt
 COPY istgt/src/istgt istgt/src/istgtcontrol /usr/local/bin/

--- a/Dockerfile.Istgtimage
+++ b/Dockerfile.Istgtimage
@@ -5,15 +5,11 @@
 FROM openebs/istgt_base:latest
 
 RUN mkdir -p /usr/local/etc/istgt
-RUN mkdir -p /tmp/cstor
 COPY istgt/src/istgt istgt/src/istgtcontrol /usr/local/bin/
 COPY istgt/src/istgt.conf istgt/src/istgtcontrol.conf /usr/local/etc/istgt/
-COPY istgt/src/istgt.conf istgt/src/istgtcontrol.conf /tmp/cstor/
 RUN touch /usr/local/etc/istgt/auth.conf
 RUN touch /usr/local/etc/istgt/logfile
 
-COPY istgt/src/init.sh /
-RUN chmod +x /init.sh
 COPY entrypoint-istgtimage.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint-istgtimage.sh
 

--- a/Dockerfile.Istgtimage
+++ b/Dockerfile.Istgtimage
@@ -8,11 +8,12 @@ RUN apt-get -y install rsyslog
 RUN apt-get -y install libssl-dev libssl1.1
 RUN apt -y install apt-file && apt-file update
 
+RUN mkdir -p /usr/local/etc/bkpistgt
 RUN mkdir -p /usr/local/etc/istgt
 COPY istgt/src/istgt istgt/src/istgtcontrol /usr/local/bin/
-COPY istgt/src/istgt.conf istgt/src/istgtcontrol.conf /usr/local/etc/istgt/
-RUN touch /usr/local/etc/istgt/auth.conf
-RUN touch /usr/local/etc/istgt/logfile
+COPY istgt.conf istgt/src/istgtcontrol.conf /usr/local/etc/bkpistgt/
+RUN touch /usr/local/etc/bkpistgt/auth.conf
+RUN touch /usr/local/etc/bkpistgt/logfile
 
 COPY entrypoint-istgtimage.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint-istgtimage.sh

--- a/Dockerfile.Istgtimage
+++ b/Dockerfile.Istgtimage
@@ -8,13 +8,17 @@ RUN apt-get -y install rsyslog
 RUN apt-get -y install libssl-dev libssl1.1
 RUN apt -y install apt-file && apt-file update
 
+RUN mkdir -p /tmp/cstor
 RUN mkdir -p /usr/local/etc/istgt
 COPY istgt/src/istgt istgt/src/istgtcontrol /usr/local/bin/
 COPY istgt/src/istgt.conf istgt/src/istgtcontrol.conf /usr/local/etc/istgt/
+COPY istgt/src/istgt.conf istgt/src/istgtcontrol.conf /tmp/cstor/
 RUN touch /usr/local/etc/istgt/auth.conf
 RUN touch /usr/local/etc/istgt/logfile
 
+COPY istgt/src/init.sh /usr/local/bin/
 COPY entrypoint-istgtimage.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/init.sh
 RUN chmod +x /usr/local/bin/entrypoint-istgtimage.sh
 
 ARG BUILD_DATE

--- a/Dockerfile.Istgtimage
+++ b/Dockerfile.Istgtimage
@@ -8,17 +8,13 @@ RUN apt-get -y install rsyslog
 RUN apt-get -y install libssl-dev libssl1.1
 RUN apt -y install apt-file && apt-file update
 
-RUN mkdir -p /tmp/cstor
 RUN mkdir -p /usr/local/etc/istgt
 COPY istgt/src/istgt istgt/src/istgtcontrol /usr/local/bin/
 COPY istgt/src/istgt.conf istgt/src/istgtcontrol.conf /usr/local/etc/istgt/
-COPY istgt/src/istgt.conf istgt/src/istgtcontrol.conf /tmp/cstor/
 RUN touch /usr/local/etc/istgt/auth.conf
 RUN touch /usr/local/etc/istgt/logfile
 
-COPY istgt/src/init.sh /usr/local/bin/
 COPY entrypoint-istgtimage.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/init.sh
 RUN chmod +x /usr/local/bin/entrypoint-istgtimage.sh
 
 ARG BUILD_DATE

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,7 +1,7 @@
 # Specify the date o build
 BUILD_DATE = $(shell date +'%Y%m%d%H%M%S')
 
-all: cstor-base-image cstor-basetest-image cstor-pool-image
+all: cstor-base-image cstor-basetest-image cstor-pool-image cstor-istgt-image
 
 cstor-build:
 	@echo "----------------------------"
@@ -22,6 +22,14 @@ cstor-pool-image:
 	@echo "----------------------------"
 	@sudo docker build -f Dockerfile.Poolimage -t openebs/cstor-pool:ci --build-arg BUILD_DATE=${BUILD_DATE} .
 	@sh push-poolimage
+
+cstor-istgt-image:
+	@echo "----------------------------"
+	@echo "--> cstor-istgt-image         "
+	@echo "----------------------------"
+	@sh cstor-istgt
+	@sudo docker build -f Dockerfile.Istgtimage -t openebs/cstor-istgt:ci --build-arg BUILD_DATE=${BUILD_DATE} .
+	@sh push-istgtimage
 
 cstor-basetest-image:
 	@echo "----------------------------"

--- a/cstor-istgt
+++ b/cstor-istgt
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ex
+
+rm -rvf istgt
+
+git clone -b replication --single-branch --depth 1 https://github.com/openebs/istgt.git
+
+echo "Clone Completed"
+
+cd istgt 
+./configure --with-replication
+make clean
+make
+
+echo "Build Completed"

--- a/entrypoint-istgtimage.sh
+++ b/entrypoint-istgtimage.sh
@@ -21,6 +21,7 @@ touch /usr/local/etc/istgt/auth.conf
 touch /usr/local/etc/istgt/logfile
 externalIP=127.0.0.1
 export externalIP=$externalIP
+service rsyslog start
 exec /usr/local/bin/istgt &
 
 child=$!

--- a/entrypoint-istgtimage.sh
+++ b/entrypoint-istgtimage.sh
@@ -10,7 +10,7 @@ echo  "exit code:" $?
 echo "reference: "  $0 
 }
 
-exec /usr/local/bin/init.sh volname=vol1 portal=127.0.0.1 path=/tmp/cstor size=10g externalIP=127.0.0.1 replication_factor=3 consistency_factor=2 &
+exec /usr/local/bin/istgt &
 
 child=$!
 wait

--- a/entrypoint-istgtimage.sh
+++ b/entrypoint-istgtimage.sh
@@ -10,6 +10,21 @@ echo  "exit code:" $?
 echo "reference: "  $0 
 }
 
+volname=vol1
+path=/tmp/cstor
+size=1G
+mkdir -p $path
+touch $volname
+truncate -s $size $path/$volname
+touch $path/sdisk.img
+truncate -s $size $path/sdisk.img
+touch /tmp/ztest1.0a
+truncate -s 1G /tmp/ztest1.0a
+cp /usr/local/etc/bkpistgt/istgt.conf /usr/local/etc/istgt/
+touch /usr/local/etc/istgt/auth.conf
+touch /usr/local/etc/istgt/logfile
+externalIP=127.0.0.1
+export externalIP=$externalIP
 exec /usr/local/bin/istgt &
 
 child=$!

--- a/entrypoint-istgtimage.sh
+++ b/entrypoint-istgtimage.sh
@@ -10,7 +10,7 @@ echo  "exit code:" $?
 echo "reference: "  $0 
 }
 
-exec /usr/local/bin/istgt &
+exec /usr/local/bin/init.sh volname=vol1 portal=127.0.0.1 path=/tmp/cstor size=10g externalIP=127.0.0.1 replication_factor=3 consistency_factor=2 &
 
 child=$!
 wait

--- a/entrypoint-istgtimage.sh
+++ b/entrypoint-istgtimage.sh
@@ -16,10 +16,6 @@ size=1G
 mkdir -p $path
 touch $volname
 truncate -s $size $path/$volname
-touch $path/sdisk.img
-truncate -s $size $path/sdisk.img
-touch /tmp/ztest1.0a
-truncate -s 1G /tmp/ztest1.0a
 cp /usr/local/etc/bkpistgt/istgt.conf /usr/local/etc/istgt/
 touch /usr/local/etc/istgt/auth.conf
 touch /usr/local/etc/istgt/logfile

--- a/entrypoint-istgtimage.sh
+++ b/entrypoint-istgtimage.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -o errexit
+trap 'call_exit $LINE_NO' EXIT
+
+call_exit()
+{
+echo "at call_exit.."     
+echo  "exit code:" $?
+echo "reference: "  $0 
+}
+
+exec /init.sh volname=vol1 portal=127.0.0.1 path=/tmp/cstor size=10g externalIP=127.0.0.1 replication_factor=3 consistency_factor=2 &
+
+child=$!
+wait
+
+

--- a/entrypoint-istgtimage.sh
+++ b/entrypoint-istgtimage.sh
@@ -10,7 +10,7 @@ echo  "exit code:" $?
 echo "reference: "  $0 
 }
 
-exec /init.sh volname=vol1 portal=127.0.0.1 path=/tmp/cstor size=10g externalIP=127.0.0.1 replication_factor=3 consistency_factor=2 &
+exec /usr/local/bin/istgt &
 
 child=$!
 wait

--- a/istgt.conf
+++ b/istgt.conf
@@ -1,0 +1,64 @@
+# Global section
+[Global]
+  NodeBase "iqn.2017-08.OpenEBS.cstor"
+  PidFile "/var/run/istgt.pid"
+  AuthFile "/usr/local/etc/istgt/auth.conf"
+  LogFile "/usr/local/etc/istgt/logfile"
+  Luworkers 1 
+  MediaDirectory "/mnt"
+  Timeout 60
+  NopInInterval 20
+  MaxR2T 16
+  DiscoveryAuthMethod None
+  DiscoveryAuthGroup None
+  MaxSessions 32
+  MaxConnections 4
+  FirstBurstLength 262144
+  MaxBurstLength 1048576
+  MaxRecvDataSegmentLength 262144
+  MaxOutstandingR2T 16
+  DefaultTime2Wait 2
+  DefaultTime2Retain 20
+  OperationalMode 0
+# UnitControl section
+[UnitControl]
+  AuthMethod None
+  AuthGroup None
+  Portal UC1 localhost:3261
+  Netmask localhost/8
+# PortalGroup section
+[PortalGroup1]
+  Portal DA1 localhost:3260
+
+# InitiatorGroup section
+[InitiatorGroup1]
+  InitiatorName "ALL"
+  Netmask "ALL"
+
+[InitiatorGroup2]
+  InitiatorName "None"
+  Netmask "None"
+
+# LogicalUnit section
+[LogicalUnit2]
+  TargetName vol1 
+  TargetAlias nicknamefor-vol1
+  Mapping PortalGroup1 InitiatorGroup1
+  AuthMethod None
+  AuthGroup None
+  UseDigest Auto
+  ReadOnly No
+  ReplicationFactor 3
+  ConsistencyFactor 2
+  UnitType Disk
+  UnitOnline Yes
+  BlockLength 512
+  QueueDepth 32
+  Luworkers 1
+  UnitInquiry "CloudByte" "iscsi" "0" "4059aab98f093c5d95207f7af09d1413"
+  PhysRecordLength 4096
+  LUN0 Storage /tmp/cstor/vol1 1G 32k
+  LUN0 Option Unmap Disable
+  LUN0 Option WZero Disable
+  LUN0 Option ATS Disable
+  LUN0 Option XCOPY Disable

--- a/push-istgtimage
+++ b/push-istgtimage
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+IMAGEID=$( sudo docker images -q openebs/cstor-istgt:ci )
+
+if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
+then 
+  sudo docker login -u "${DNAME}" -p "${DPASS}";
+  # Push image to docker hub
+  sudo docker push openebs/cstor-istgt:ci ;
+  if [ ! -z "${TRAVIS_TAG}" ] ; 
+  then
+    # Push with different tags if tagged as a release
+    # When github is tagged with a release, then Travis will 
+    # set the release tag in env TRAVIS_TAG
+    sudo docker tag ${IMAGEID} openebs/cstor-istgt:${TRAVIS_TAG}
+    sudo docker push openebs/cstor-istgt:${TRAVIS_TAG}; 
+    sudo docker tag ${IMAGEID} openebs/cstor-istgt:latest
+    sudo docker push openebs/cstor-istgt:latest; 
+  fi;
+else
+  echo "No docker credentials provided. Skip uploading openebs/cstor-istgt:ci to docker hub"; 
+fi;


### PR DESCRIPTION
…ore.

Signed-off-by: moteesh <moteesh@gmail.com>

This commit adds the cstor-istgt-image target into cstor makefile so that when make is invoked
istgt docker image will be built along with other images.

Changes to be committed:
A       .gitignore
A       Dockerfile.Istgtimage
M       GNUmakefile
A       cstor-istgt
A       entrypoint-istgtimage.sh
A       push-istgtimage

1.Why is this change necessary ?
To build istgt docker image and push it to dockerhub upon making cstor.
2. How does this change address the issue ?
This commit adds the docker file and required scripts to build istgt and push image to dockerhub. GNUMakefile has been added with a new target called cstor-istgt-image which builds the docker image and push the image to dockerhub
3. How to verify this change ?
Do make in cstor directory and verify the docker image of istgt gets built.
4. What side effects does this change have ?
5. Other details