### PR TITLE
Add cStorPool and cStorVolumeReplica commands

### DIFF
--- a/cstorpool-volume-cmds
+++ b/cstorpool-volume-cmds
@@ -1,18 +1,25 @@
 CStorPool commands:
 Create Pool : 
+To create zpool with cachefile and alias name in io.openebs:poolname for disk and guid as zpool name.
 zpool create [-o cachefile=/tmp/pool1.cache -O io.openebs:poolname=poolname] <pool1-guid> /dev/sdc1
 
 Delete Pool: 
+To destroy zpool with same name provided in zpool create,
 zpool destroy <pool1-guid>
 
 Import Pool: 
-zpool import [-o /tmp/pool1.cache -c /tmp/pool1.cache] <pool1-guid>
+To import zpool with cachefile and poolname,
+zpool import [-c /tmp/pool1.cache] <pool1-guid>
+To import zpool without cachefile,
+zpool import <pool1-guid>
 
 Get Pool: 
+To get poolname without table format -Hp flag is used and to get particular column -o is used.
 zpool get -Hp name -o name
 zpool get <pool-guid>
 
 Clear pool label: 
+The labels written to disk on previous zpool creation needs to be cleared.
 zpool labelclear -f <disk details>
 
 IsZreplRunning: 
@@ -31,16 +38,20 @@ errors: No known data errors
 ```
 
 Set cachefile:
-zpool set cachefile <pool-guid>
+Cachefile is for faster importing of pool. To set cachefile for particular pool,
+zpool set cachefile=<pool.cache> <pool-guid>
 
 CStorVolumeReplica commands:
 Create Volume: 
+To create zfs volume of particular size on top of zpool with guid specifying target ip and alias name-io.openebs:volname.
 zfs create -V 1G <pool1-guid>/<vol1-guid> -o io.openebs:targetip=IP:PORT -o io.openebs:volname=volname
 
 Delete Volume: 
+To destroy zfs volume,
 zfs destroy <pool1-guid>/<vol1-guid>
 
 Get Volume: 
+To get volume name without table format -Hp flag is used and to get particular column -o is used.
 zfs get -Hp name -o name
 ```
 pool1

--- a/cstorpool-volume-cmds
+++ b/cstorpool-volume-cmds
@@ -1,0 +1,16 @@
+CStorPool commands:
+Create Pool : zpool create [-o cachefile=/tmp/pool1.cache -o io.openebs:poolname=poolname] <guid-pool1> /dev/sdc1
+Delete Pool: zpool destroy <guid-pool1>
+Import Pool: zpool import [-o /tmp/pool1.cache -c /tmp/pool1.cache] <guid-pool1>
+Get Pool: zpool get -Hp name -o name
+Zpool get <pool-guid>
+Clear pool label: zpool labelclear -f <disk details>
+IsZreplRunning: zpool status(only exit status check)
+
+CStorVolumeReplica commands:
+Create Volume: zfs create -V 1G <guid-pool1>/<guid-vol1> -o io.openebs:targetip=IP:PORT -o io.openebs:volname=volname
+Delete Volume: zfs destroy guid-pool1/guid-vol1
+Get Volume: zfs get -Hp name -o name
+Get io.openebs:volname property : zfs get io.openebs:volname <poolguid>/<volguid>
+
+

--- a/cstorpool-volume-cmds
+++ b/cstorpool-volume-cmds
@@ -1,6 +1,8 @@
 CStorPool commands:
 Create Pool : 
-To create zpool with cachefile and alias name in io.openebs:poolname for disk and guid as zpool name.
+To create zpool on specified disk with cachefile and alias name in io.openebs:poolname and guid as zpool name.
+Cachefile is for faster import of pool. Since guid is being used for poolname, alias name(e.g., testpool)
+ensures readability.
 zpool create [-o cachefile=/tmp/pool1.cache -O io.openebs:poolname=poolname] <pool1-guid> /dev/sdc1
 
 Delete Pool: 
@@ -43,7 +45,7 @@ zpool set cachefile=<pool.cache> <pool-guid>
 
 CStorVolumeReplica commands:
 Create Volume: 
-To create zfs volume of particular size on top of zpool with guid specifying target ip and alias name-io.openebs:volname.
+To create zfs volume of particular size on top of zpool with guid specifying target ip and alias in name-io.openebs:volname.
 zfs create -V 1G <pool1-guid>/<vol1-guid> -o io.openebs:targetip=IP:PORT -o io.openebs:volname=volname
 
 Delete Volume: 

--- a/cstorpool-volume-cmds
+++ b/cstorpool-volume-cmds
@@ -1,12 +1,11 @@
 CStorPool commands:
 Create Pool : 
-To create zpool on specified disk with cachefile and alias name in io.openebs:poolname and guid as zpool name.
-Cachefile is for faster import of pool. Since guid is being used for poolname, alias name(e.g., testpool)
-ensures readability.
+To create zpool on a specified disk with cachefile and alias name in io.openebs:poolname and guid as zpool name.
+Cachefile helps in importing a pool faster. Guid is used for poolname and alias name, for example testpool, which ensures readability.
 zpool create [-o cachefile=/tmp/pool1.cache -O io.openebs:poolname=poolname] <pool1-guid> /dev/sdc1
 
 Delete Pool: 
-To destroy zpool with same name provided in zpool create,
+Destroys zpool with the same name you provided while creating zpool.
 zpool destroy <pool1-guid>
 
 Import Pool: 
@@ -21,7 +20,7 @@ zpool get -Hp name -o name
 zpool get <pool-guid>
 
 Clear pool label: 
-The labels written to disk on previous zpool creation needs to be cleared.
+The labels written to disk on previous zpool creation must be cleared.
 zpool labelclear -f <disk details>
 
 IsZreplRunning: 
@@ -40,7 +39,7 @@ errors: No known data errors
 ```
 
 Set cachefile:
-Cachefile is for faster importing of pool. To set cachefile for particular pool,
+Cachefile helps in importing a pool faster. To set cachefile for particular pool,
 zpool set cachefile=<pool.cache> <pool-guid>
 
 CStorVolumeReplica commands:

--- a/cstorpool-volume-cmds
+++ b/cstorpool-volume-cmds
@@ -1,16 +1,56 @@
 CStorPool commands:
-Create Pool : zpool create [-o cachefile=/tmp/pool1.cache -o io.openebs:poolname=poolname] <guid-pool1> /dev/sdc1
-Delete Pool: zpool destroy <guid-pool1>
-Import Pool: zpool import [-o /tmp/pool1.cache -c /tmp/pool1.cache] <guid-pool1>
-Get Pool: zpool get -Hp name -o name
-Zpool get <pool-guid>
-Clear pool label: zpool labelclear -f <disk details>
-IsZreplRunning: zpool status(only exit status check)
+Create Pool : 
+zpool create [-o cachefile=/tmp/pool1.cache -O io.openebs:poolname=poolname] <pool1-guid> /dev/sdc1
+
+Delete Pool: 
+zpool destroy <pool1-guid>
+
+Import Pool: 
+zpool import [-o /tmp/pool1.cache -c /tmp/pool1.cache] <pool1-guid>
+
+Get Pool: 
+zpool get -Hp name -o name
+zpool get <pool-guid>
+
+Clear pool label: 
+zpool labelclear -f <disk details>
+
+IsZreplRunning: 
+zpool status(only exit status check)
+```
+  pool: pool1
+ state: ONLINE
+  scan: none requested
+config:
+
+	NAME              STATE     READ WRITE CKSUM
+	pool1             ONLINE       0     0     0
+	  /dev/sdc1       ONLINE       0     0     0
+
+errors: No known data errors
+```
+
+Set cachefile:
+zpool set cachefile <pool-guid>
 
 CStorVolumeReplica commands:
-Create Volume: zfs create -V 1G <guid-pool1>/<guid-vol1> -o io.openebs:targetip=IP:PORT -o io.openebs:volname=volname
-Delete Volume: zfs destroy guid-pool1/guid-vol1
-Get Volume: zfs get -Hp name -o name
-Get io.openebs:volname property : zfs get io.openebs:volname <poolguid>/<volguid>
+Create Volume: 
+zfs create -V 1G <pool1-guid>/<vol1-guid> -o io.openebs:targetip=IP:PORT -o io.openebs:volname=volname
 
+Delete Volume: 
+zfs destroy <pool1-guid>/<vol1-guid>
+
+Get Volume: 
+zfs get -Hp name -o name
+```
+pool1
+pool1/vol1
+```
+
+Get io.openebs:volname property : 
+zfs get io.openebs:volname <poolguid>/<volguid>
+```
+pool1
+pool1/vol1
+```
 


### PR DESCRIPTION
1. Why is this change necessary ?
fixes: openebs/openebs#1501

2. How does this change address the issue ?
Customized zpool and zfs commands used to create, delete and get pool and volumereplica
are written.

3. How to verify this change ?
This will be made use of when the business logic is implemented and merged.

Signed-off-by: gkGaneshR <gkganesh126@gmail.com>