### PR TITLE
Update zrepl command and remove rsyslog

### DIFF
--- a/entrypoint-poolimage.sh
+++ b/entrypoint-poolimage.sh
@@ -10,11 +10,7 @@ echo  "exit code:" $?
 echo "reference: "  $0 
 }
 
-exec /usr/local/bin/zrepl > /var/log/zrepl.out &
-exec service ssh start &
-exec service rsyslog start &
-
-child=$!
-wait
+service ssh start
+exec /usr/local/bin/zrepl
 
 


### PR DESCRIPTION
1. Why is this change necessary ?
fixes: openebs/openebs#1609

2. How does this change address the issue ?
zrepl logs need not be written onto log file. It can be printed
on console and syslog package is also not required.

3. How to verify this change ?
docker run will verify. It will also be used in cstor-pool pod.

Signed-off-by: gkGaneshR <gkganesh126@gmail.com>