### PR TITLE
Having empty istgt conf file during entrypoint

### DIFF
--- a/Dockerfile.Istgtimage
+++ b/Dockerfile.Istgtimage
@@ -12,6 +12,7 @@ RUN apt -y install apt-file && apt-file update
 RUN mkdir -p /usr/local/etc/bkpistgt
 RUN mkdir -p /usr/local/etc/istgt
 COPY istgt/src/istgt istgt/src/istgtcontrol /usr/local/bin/
+COPY istgt/src/istgt.full istgt/src/istgtcontrol.full /usr/local/bin/
 COPY istgt/src/istgt.conf istgt/src/istgtcontrol.conf /usr/local/etc/bkpistgt/
 RUN touch /usr/local/etc/bkpistgt/auth.conf
 RUN touch /usr/local/etc/bkpistgt/logfile

--- a/entrypoint-istgtimage.sh
+++ b/entrypoint-istgtimage.sh
@@ -16,6 +16,8 @@ touch /usr/local/etc/istgt/auth.conf
 touch /usr/local/etc/istgt/logfile
 export externalIP=0.0.0.0
 service rsyslog start
+sed -i -n '/LogicalUnit section/,$!p' /usr/local/etc/istgt/istgt.conf
+
 exec /usr/local/bin/istgt &
 
 child=$!


### PR DESCRIPTION
This PR have below two changes:

1. Copying istgt binary with symbols to help during debugging

2. Instead of having dummy LU configuration, istgt need to be started with empty configuration.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>