### PR TITLE
changed base docker image to ubuntu 14.04 in order to make it compatible with travis build pipeline.

### DIFF
--- a/Dockerfile.Istgtimage
+++ b/Dockerfile.Istgtimage
@@ -2,11 +2,11 @@
 # This Dockerfile builds cstor istgt container running istgt from istgt base image
 #
 
-FROM ubuntu:18.04
+FROM ubuntu:14.04
 RUN apt-get update; exit 0
 RUN apt-get -y install rsyslog
 RUN apt-get -y install net-tools iputils-ping
-RUN apt-get -y install libssl-dev libssl1.1 libjson-c-dev
+RUN apt-get -y install libssl-dev libjson-c-dev
 RUN apt -y install apt-file && apt-file update
 
 RUN mkdir -p /usr/local/etc/bkpistgt


### PR DESCRIPTION

changed base docker image to ubuntu 14.04 in order to make it compatible with travis build pipeline.
Signed-off-by: moteesh <moteesh@gmail.com>