### PR TITLE
[US2543] Removing copying istgt.full and istgtcontrol.full to ISTGT docker image

### DIFF
--- a/Dockerfile.Istgtimage
+++ b/Dockerfile.Istgtimage
@@ -12,7 +12,6 @@ RUN apt -y install apt-file && apt-file update
 RUN mkdir -p /usr/local/etc/bkpistgt
 RUN mkdir -p /usr/local/etc/istgt
 COPY istgt/src/istgt istgt/src/istgtcontrol /usr/local/bin/
-COPY istgt/src/istgt.full istgt/src/istgtcontrol.full /usr/local/bin/
 COPY istgt/src/istgt.conf istgt/src/istgtcontrol.conf /usr/local/etc/bkpistgt/
 RUN touch /usr/local/etc/bkpistgt/auth.conf
 RUN touch /usr/local/etc/bkpistgt/logfile


### PR DESCRIPTION
Changes :  
- Removing copying istgt.full and istgtcontrol.full to ISTGT docker image due to changes in ISTGT build.

Signed-off-by: mayank <mayank.patel@cloudbyte.com>