### PR TITLE
[US2930] Add image tag in the docker builds

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,14 +14,14 @@ cstor-base-image: cstor-build
 	@echo "--> cstor-base-image         "
 	@echo "----------------------------"
 	@sudo docker build -f Dockerfile.Baseimage -t openebs/cstor-base:ci --build-arg BUILD_DATE=${BUILD_DATE} .       
-	@sh push-baseimage
+	@bash push-baseimage
 
 cstor-pool-image:
 	@echo "----------------------------"
 	@echo "--> cstor-pool-image         "
 	@echo "----------------------------"
 	@sudo docker build -f Dockerfile.Poolimage -t openebs/cstor-pool:ci --build-arg BUILD_DATE=${BUILD_DATE} .
-	@sh push-poolimage
+	@bash push-poolimage
 
 cstor-istgt-image:
 	@echo "----------------------------"
@@ -29,14 +29,14 @@ cstor-istgt-image:
 	@echo "----------------------------"
 	@sh cstor-istgt
 	@sudo docker build -f Dockerfile.Istgtimage -t openebs/cstor-istgt:ci --build-arg BUILD_DATE=${BUILD_DATE} .
-	@sh push-istgtimage
+	@bash push-istgtimage
 
 cstor-basetest-image:
 	@echo "----------------------------"
 	@echo "--> cstor-baseshared-image         "
 	@echo "----------------------------"
 	@sudo docker build -f Dockerfile.BaseTestImage -t openebs/cstor-test:ci --build-arg BUILD_DATE=${BUILD_DATE} .
-	@sh push-basetestimage
+	@bash push-basetestimage
 
 prerequisites:
 	@echo "----------------------------"

--- a/image-tag
+++ b/image-tag
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Specify the date of build
+BUILD_DATE=$(date +'%Y%m%d%H%M%S')
+# Specify the build tag
+RELEASE_TAG="dev"
+VERSION="${RELEASE_TAG}-${BUILD_DATE}"
+IMAGE_TAG=${VERSION}
+export IMAGE_TAG

--- a/push-baseimage
+++ b/push-baseimage
@@ -4,21 +4,26 @@ set -e
 source "image-tag"
 IMAGEID=$( sudo docker images -q openebs/cstor-base:ci )
 
-if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
-then 
+if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ];
+then
   sudo docker login -u "${DNAME}" -p "${DPASS}";
   # Push image to docker hub
   sudo docker push openebs/cstor-base:ci ;
-  if [ ! -z "${IMAGE_TAG}" ] ; 
+  if [ ! -z "${TRAVIS_TAG}" ] ;
   then
     # Push with different tags if tagged as a release
-    # When github is tagged with a release, then Travis will 
-    # set the release tag in env IMAGE_TAG
-    sudo docker tag ${IMAGEID} openebs/cstor-base:${IMAGE_TAG}
-    sudo docker push openebs/cstor-base:${IMAGE_TAG}; 
+    # When github is tagged with a release, then Travis will
+    # set the release tag in env TRAVIS_TAG
+    sudo docker tag ${IMAGEID} openebs/cstor-base:${TRAVIS_TAG}
+    sudo docker push openebs/cstor-base:${TRAVIS_TAG};
     sudo docker tag ${IMAGEID} openebs/cstor-base:latest
-    sudo docker push openebs/cstor-base:latest; 
+    sudo docker push openebs/cstor-base:latest;
+  fi;
+  if [ ! -z "${IMAGE_TAG}" ] ;
+  then
+    sudo docker tag ${IMAGEID} openebs/cstor-base:${IMAGE_TAG}
+    sudo docker push openebs/cstor-base:${IMAGE_TAG};
   fi;
 else
-  echo "No docker credentials provided. Skip uploading openebs/cstor-base:ci to docker hub"; 
+  echo "No docker credentials provided. Skip uploading openebs/cstor-base:ci to docker hub";
 fi;

--- a/push-baseimage
+++ b/push-baseimage
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+source "$(dirname $0)/image-tag"
 IMAGEID=$( sudo docker images -q openebs/cstor-base:ci )
 
 if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
@@ -8,13 +9,13 @@ then
   sudo docker login -u "${DNAME}" -p "${DPASS}";
   # Push image to docker hub
   sudo docker push openebs/cstor-base:ci ;
-  if [ ! -z "${TRAVIS_TAG}" ] ; 
+  if [ ! -z "${IMAGE_TAG}" ] ; 
   then
     # Push with different tags if tagged as a release
     # When github is tagged with a release, then Travis will 
-    # set the release tag in env TRAVIS_TAG
-    sudo docker tag ${IMAGEID} openebs/cstor-base:${TRAVIS_TAG}
-    sudo docker push openebs/cstor-base:${TRAVIS_TAG}; 
+    # set the release tag in env IMAGE_TAG
+    sudo docker tag ${IMAGEID} openebs/cstor-base:${IMAGE_TAG}
+    sudo docker push openebs/cstor-base:${IMAGE_TAG}; 
     sudo docker tag ${IMAGEID} openebs/cstor-base:latest
     sudo docker push openebs/cstor-base:latest; 
   fi;

--- a/push-baseimage
+++ b/push-baseimage
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source "$(dirname $0)/image-tag"
+source "image-tag"
 IMAGEID=$( sudo docker images -q openebs/cstor-base:ci )
 
 if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 

--- a/push-basetestimage
+++ b/push-basetestimage
@@ -1,23 +1,24 @@
 #!/bin/bash
 set -e
 
+source "$(dirname $0)/image-tag"
 IMAGEID=$( sudo docker images -q openebs/cstor-test:ci )
 
-if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
-then 
+if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ];
+then
   sudo docker login -u "${DNAME}" -p "${DPASS}";
   # Push image to docker hub
   sudo docker push openebs/cstor-test:ci ;
-  if [ ! -z "${TRAVIS_TAG}" ] ; 
+  if [ ! -z "${IMAGE_TAG}" ] ;
   then
     # Push with different tags if tagged as a release
-    # When github is tagged with a release, then Travis will 
-    # set the release tag in env TRAVIS_TAG
-    sudo docker tag ${IMAGEID} openebs/cstor-test:${TRAVIS_TAG}
-    sudo docker push openebs/cstor-test:${TRAVIS_TAG}; 
+    # When github is tagged with a release, then Travis will
+    # set the release tag in env IMAGE_TAG
+    sudo docker tag ${IMAGEID} openebs/cstor-test:${IMAGE_TAG}
+    sudo docker push openebs/cstor-test:${IMAGE_TAG};
     sudo docker tag ${IMAGEID} openebs/cstor-test:latest
-    sudo docker push openebs/cstor-test:latest; 
+    sudo docker push openebs/cstor-test:latest;
   fi;
 else
-  echo "No docker credentials provided. Skip uploading openebs/cstor-test:ci to docker hub"; 
+  echo "No docker credentials provided. Skip uploading openebs/cstor-test:ci to docker hub";
 fi;

--- a/push-basetestimage
+++ b/push-basetestimage
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source "$(dirname $0)/image-tag"
+source "image-tag"
 IMAGEID=$( sudo docker images -q openebs/cstor-test:ci )
 
 if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ];

--- a/push-basetestimage
+++ b/push-basetestimage
@@ -9,15 +9,20 @@ then
   sudo docker login -u "${DNAME}" -p "${DPASS}";
   # Push image to docker hub
   sudo docker push openebs/cstor-test:ci ;
-  if [ ! -z "${IMAGE_TAG}" ] ;
+  if [ ! -z "${TRAVIS_TAG}" ] ;
   then
     # Push with different tags if tagged as a release
     # When github is tagged with a release, then Travis will
-    # set the release tag in env IMAGE_TAG
-    sudo docker tag ${IMAGEID} openebs/cstor-test:${IMAGE_TAG}
-    sudo docker push openebs/cstor-test:${IMAGE_TAG};
+    # set the release tag in env TRAVIS_TAG
+    sudo docker tag ${IMAGEID} openebs/cstor-test:${TRAVIS_TAG}
+    sudo docker push openebs/cstor-test:${TRAVIS_TAG};
     sudo docker tag ${IMAGEID} openebs/cstor-test:latest
     sudo docker push openebs/cstor-test:latest;
+  fi;
+  if [ ! -z "${IMAGE_TAG}" ] ;
+  then
+    sudo docker tag ${IMAGEID} openebs/cstor-test:${IMAGE_TAG}
+    sudo docker push openebs/cstor-test:${IMAGE_TAG};
   fi;
 else
   echo "No docker credentials provided. Skip uploading openebs/cstor-test:ci to docker hub";

--- a/push-istgtimage
+++ b/push-istgtimage
@@ -5,21 +5,26 @@ source "image-tag"
 IMAGEID=$( sudo docker images -q openebs/cstor-istgt:ci )
 echo ${IMAGEID}
 
-if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
-then 
+if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ];
+then
   sudo docker login -u "${DNAME}" -p "${DPASS}";
   # Push image to docker hub
   sudo docker push openebs/cstor-istgt:ci ;
-  if [ ! -z "${IMAGE_TAG}" ] ; 
+  if [ ! -z "${TRAVIS_TAG}" ] ;
   then
     # Push with different tags if tagged as a release
-    # When github is tagged with a release, then Travis will 
-    # set the release tag in env IMAGE_TAG
-    sudo docker tag ${IMAGEID} openebs/cstor-istgt:${IMAGE_TAG}
-    sudo docker push openebs/cstor-istgt:${IMAGE_TAG}; 
+    # When github is tagged with a release, then Travis will
+    # set the release tag in env TRAVIS_TAG
+    sudo docker tag ${IMAGEID} openebs/cstor-istgt:${TRAVIS_TAG}
+    sudo docker push openebs/cstor-istgt:${TRAVIS_TAG};
     sudo docker tag ${IMAGEID} openebs/cstor-istgt:latest
-    sudo docker push openebs/cstor-istgt:latest; 
+    sudo docker push openebs/cstor-istgt:latest;
+  fi;
+  if [ ! -z "${IMAGE_TAG}" ] ;
+  then
+    sudo docker tag ${IMAGEID} utkarshmani1997/cstor-istgt:${IMAGE_TAG}
+    sudo docker push openebs/cstor-istgt:${IMAGE_TAG};
   fi;
 else
-  echo "No docker credentials provided. Skip uploading openebs/cstor-istgt:ci to docker hub"; 
+  echo "No docker credentials provided. Skip uploading openebs/cstor-istgt:ci to docker hub";
 fi;

--- a/push-istgtimage
+++ b/push-istgtimage
@@ -1,20 +1,22 @@
 #!/bin/bash
 set -e
 
+source "$(dirname $0)/image-tag"
 IMAGEID=$( sudo docker images -q openebs/cstor-istgt:ci )
+echo ${IMAGEID}
 
 if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
 then 
   sudo docker login -u "${DNAME}" -p "${DPASS}";
   # Push image to docker hub
   sudo docker push openebs/cstor-istgt:ci ;
-  if [ ! -z "${TRAVIS_TAG}" ] ; 
+  if [ ! -z "${IMAGE_TAG}" ] ; 
   then
     # Push with different tags if tagged as a release
     # When github is tagged with a release, then Travis will 
-    # set the release tag in env TRAVIS_TAG
-    sudo docker tag ${IMAGEID} openebs/cstor-istgt:${TRAVIS_TAG}
-    sudo docker push openebs/cstor-istgt:${TRAVIS_TAG}; 
+    # set the release tag in env IMAGE_TAG
+    sudo docker tag ${IMAGEID} openebs/cstor-istgt:${IMAGE_TAG}
+    sudo docker push openebs/cstor-istgt:${IMAGE_TAG}; 
     sudo docker tag ${IMAGEID} openebs/cstor-istgt:latest
     sudo docker push openebs/cstor-istgt:latest; 
   fi;

--- a/push-istgtimage
+++ b/push-istgtimage
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source "$(dirname $0)/image-tag"
+source "image-tag"
 IMAGEID=$( sudo docker images -q openebs/cstor-istgt:ci )
 echo ${IMAGEID}
 

--- a/push-poolimage
+++ b/push-poolimage
@@ -9,15 +9,20 @@ then
   sudo docker login -u "${DNAME}" -p "${DPASS}";
   # Push image to docker hub
   sudo docker push openebs/cstor-pool:ci ;
-  if [ ! -z "${IMAGE_TAG}" ] ;
+  if [ ! -z "${TRAVIS_TAG}" ] ;
   then
     # Push with different tags if tagged as a release
     # When github is tagged with a release, then Travis will
-    # set the release tag in env IMAGE_TAG
-    sudo docker tag ${IMAGEID} openebs/cstor-pool:${IMAGE_TAG}
-    sudo docker push openebs/cstor-pool:${IMAGE_TAG};
+    # set the release tag in env TRAVIS_TAG
+    sudo docker tag ${IMAGEID} openebs/cstor-pool:${TRAVIS_TAG}
+    sudo docker push openebs/cstor-pool:${TRAVIS_TAG};
     sudo docker tag ${IMAGEID} openebs/cstor-pool:latest
     sudo docker push openebs/cstor-pool:latest;
+  fi;
+  if [ ! -z "${IMAGE_TAG}" ] ;
+  then
+    sudo docker tag ${IMAGEID} openebs/cstor-pool:${IMAGE_TAG}
+    sudo docker push openebs/cstor-pool:${IMAGE_TAG};
   fi;
 else
   echo "No docker credentials provided. Skip uploading openebs/cstor-pool:ci to docker hub";

--- a/push-poolimage
+++ b/push-poolimage
@@ -1,23 +1,24 @@
 #!/bin/bash
 set -e
 
+source "$(dirname $0)/image-tag"
 IMAGEID=$( sudo docker images -q openebs/cstor-pool:ci )
 
-if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
-then 
+if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ];
+then
   sudo docker login -u "${DNAME}" -p "${DPASS}";
   # Push image to docker hub
   sudo docker push openebs/cstor-pool:ci ;
-  if [ ! -z "${TRAVIS_TAG}" ] ; 
+  if [ ! -z "${IMAGE_TAG}" ] ;
   then
     # Push with different tags if tagged as a release
-    # When github is tagged with a release, then Travis will 
-    # set the release tag in env TRAVIS_TAG
-    sudo docker tag ${IMAGEID} openebs/cstor-pool:${TRAVIS_TAG}
-    sudo docker push openebs/cstor-pool:${TRAVIS_TAG}; 
+    # When github is tagged with a release, then Travis will
+    # set the release tag in env IMAGE_TAG
+    sudo docker tag ${IMAGEID} openebs/cstor-pool:${IMAGE_TAG}
+    sudo docker push openebs/cstor-pool:${IMAGE_TAG};
     sudo docker tag ${IMAGEID} openebs/cstor-pool:latest
-    sudo docker push openebs/cstor-pool:latest; 
+    sudo docker push openebs/cstor-pool:latest;
   fi;
 else
-  echo "No docker credentials provided. Skip uploading openebs/cstor-pool:ci to docker hub"; 
+  echo "No docker credentials provided. Skip uploading openebs/cstor-pool:ci to docker hub";
 fi;

--- a/push-poolimage
+++ b/push-poolimage
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source "$(dirname $0)/image-tag"
+source "image-tag"
 IMAGEID=$( sudo docker images -q openebs/cstor-pool:ci )
 
 if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ];


### PR DESCRIPTION
[US2930] This commit adds image-tag in all the docker builds. Now the docker images will be created like following : `openebs/cstor-istgt:dev-20180820135108`
Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>