### PR TITLE
replace utkarshmani1997 to openebs in push script

### DIFF
--- a/push-istgtimage
+++ b/push-istgtimage
@@ -22,7 +22,7 @@ then
   fi;
   if [ ! -z "${IMAGE_TAG}" ] ;
   then
-    sudo docker tag ${IMAGEID} utkarshmani1997/cstor-istgt:${IMAGE_TAG}
+    sudo docker tag ${IMAGEID} openebs/cstor-istgt:${IMAGE_TAG}
     sudo docker push openebs/cstor-istgt:${IMAGE_TAG};
   fi;
 else


### PR DESCRIPTION
The repository name for the docker was utkarshmani1997 instead of openebs. This commit fix that mistake.
Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>