### PR TITLE
added sleep of 2 seconds in the zrepl entrypoint script

### DIFF
--- a/entrypoint-poolimage.sh
+++ b/entrypoint-poolimage.sh
@@ -15,4 +15,6 @@ service ssh start
 if [ -z "$LOGLEVEL" ]; then
 	LOGLEVEL=info
 fi
+echo "sleeping for 2 sec"
+sleep 2
 exec /usr/local/bin/zrepl -l $LOGLEVEL


### PR DESCRIPTION
so that the healthcheck logic in pool mgmt CRD watcher works.

Signed-off-by: moteesh <moteesh@gmail.com>