### PR TITLE
do ld_preload on jemalloc to use it by zrepl

### DIFF
--- a/entrypoint-poolimage.sh
+++ b/entrypoint-poolimage.sh
@@ -17,4 +17,5 @@ if [ -z "$LOGLEVEL" ]; then
 fi
 echo "sleeping for 2 sec"
 sleep 2
+export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
 exec /usr/local/bin/zrepl -l $LOGLEVEL


### PR DESCRIPTION
This PR is to use jemalloc for zrepl binary in cstor-pool container. This increases performance of pool, and also, stabilizes memory usage.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>