### PR TITLE
Make istgt use libjemalloc

### DIFF
--- a/Dockerfile.Istgtimage
+++ b/Dockerfile.Istgtimage
@@ -6,7 +6,7 @@ FROM ubuntu:14.04
 RUN apt-get update; exit 0
 RUN apt-get -y install rsyslog
 RUN apt-get -y install net-tools iputils-ping
-RUN apt-get -y install libssl-dev libjson-c-dev
+RUN apt-get -y install libssl-dev libjson-c-dev libjemalloc-dev
 RUN apt -y install apt-file && apt-file update
 
 RUN mkdir -p /usr/local/etc/bkpistgt

--- a/entrypoint-istgtimage.sh
+++ b/entrypoint-istgtimage.sh
@@ -20,6 +20,7 @@ touch /usr/local/etc/istgt/logfile
 export externalIP=0.0.0.0
 service rsyslog start
 
+export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
 exec /usr/local/bin/istgt &
 
 child=$!


### PR DESCRIPTION
This PR is to make istgt container to use libjemalloc for better memory utilization and to avoid memory fragmentation.
Signed-off-by: Vishnu Itta <vitta@mayadata.io>