### PR TITLE
fix(build): prefix the branch name to docker images for non-master

### DIFF
--- a/cstor-container
+++ b/cstor-container
@@ -66,7 +66,7 @@ then
     else
         echo "checkout code from branch: ${TRAVIS_BRANCH}"
         git checkout ${TRAVIS_BRANCH}
-        rc=$?; if [ $rc -ne 0 ]; then git checkout ${ZFS_MASTER}; exit; fi
+        rc=$?; if [ $rc -ne 0 ]; then git checkout ${ZFS_MASTER}; fi
     fi;
 fi;
 

--- a/cstor-container
+++ b/cstor-container
@@ -4,22 +4,25 @@ set -e
 rm -rvf zfs
 rm -rvf spl
 
+ZFS_MASTER="zfs-0.7-release"
+SPL_STABLE_TAG="spl-0.7.9"
+
 if [ ! -z "${GITHUB_USER_NAME}" ] && [ ! -z "${GITHUB_API_KEY}" ] && [ ! -z "${TRAVIS_TAG}" ];
 then
     git clone https://${GITHUB_USER_NAME}:${GITHUB_API_KEY}@github.com/openebs/zfs zfs
     git clone https://${GITHUB_USER_NAME}:${GITHUB_API_KEY}@github.com/openebs/spl spl
 
     echo "Clone Completed"
-    echo "chore(release): tagging zfs and spl for ${TRAVIS_TAG} release"
+    echo "tagging zfs and spl for ${TRAVIS_TAG} release"
 
     cd spl
-    git checkout spl-0.7.9
+    git checkout ${SPL_STABLE_TAG}
     git tag ${TRAVIS_TAG}
     git push origin ${TRAVIS_TAG}
     echo "pushed the tag: ${TRAVIS_TAG} to spl repository"
 
     cd ../zfs
-    git checkout zfs-0.7-release
+    git checkout ${ZFS_MASTER}
     git tag ${TRAVIS_TAG}
     git push origin ${TRAVIS_TAG}
     echo "pushed the tag: ${TRAVIS_TAG} to zfs repository"
@@ -32,23 +35,41 @@ else
 fi;
 
 cd spl
-if [ ! -z "${GITHUB_USER_NAME}" ] && [ ! -z "${GITHUB_API_KEY}" ] && [ ! -z "${TRAVIS_TAG}" ];
+if [ ! -z "${TRAVIS_TAG}" ];
 then
     git checkout ${TRAVIS_TAG}
 else
-    git checkout spl-0.7.9
+    # Note: Currently there is no change in the spl code base
+    # always use the upstream stable tag
+    git checkout ${SPL_STABLE_TAG}
 fi;
 sh autogen.sh
 ./configure
 make
 
 cd ../zfs
-if [ ! -z "${GITHUB_USER_NAME}" ] && [ ! -z "${GITHUB_API_KEY}" ] && [ ! -z "${TRAVIS_TAG}" ];
+#Checkout the correct zfs code base for compilation
+# - Release Tag
+# - Master branch  - will use active dev branch (zfs-0.7-release)
+# - Non-master branch - checkout with branch name or 
+#   will fallback to active dev branch
+if [ ! -z "${TRAVIS_TAG}" ];
 then
+    echo "checkout code from release tag: ${TRAVIS_TAG}"
     git checkout ${TRAVIS_TAG}
-else
-    git checkout zfs-0.7-release
+elif [ ! -z "${TRAVIS_BRANCH}" ];
+then
+    if [ $TRAVIS_BRANCH = "master" ];
+    then
+        echo "checkout code from branch: ${ZFS_MASTER}"
+        git checkout ${ZFS_MASTER}
+    else
+        echo "checkout code from branch: ${TRAVIS_BRANCH}"
+        git checkout ${TRAVIS_BRANCH}
+        rc=$?; if [ $rc -ne 0 ]; then git checkout ${ZFS_MASTER}; exit; fi
+    fi;
 fi;
+
 sh autogen.sh
 ./configure --enable-uzfs=yes --with-config=user --with-jemalloc
 make

--- a/cstor-istgt
+++ b/cstor-istgt
@@ -2,28 +2,51 @@
 set -e
 
 rm -rvf istgt
+
+ISTGT_MASTER="replication"
+
 if [ ! -z "${GITHUB_USER_NAME}" ] && [ ! -z "${GITHUB_API_KEY}" ] && [ ! -z "${TRAVIS_TAG}" ];
 then
-    git clone -b replication --single-branch --depth 1 https://${GITHUB_USER_NAME}:${GITHUB_API_KEY}@github.com/openebs/istgt istgt
+    git clone -b ${ISTGT_MASTER} --single-branch --depth 1 https://${GITHUB_USER_NAME}:${GITHUB_API_KEY}@github.com/openebs/istgt istgt
     echo "Clone Completed"
-    echo "chore(release): tagging istgt for ${TRAVIS_TAG} release"
 
     cd istgt
+    echo "tagging istgt for ${TRAVIS_TAG} release"
     git tag ${TRAVIS_TAG}
     git push origin ${TRAVIS_TAG}
     echo "pushed the tag: ${TRAVIS_TAG} to istgt repository"
     cd ..
 else
-    git clone -b replication --single-branch --depth 1 https://github.com/openebs/istgt.git
-
+    git clone -b ${ISTGT_MASTER} --single-branch --depth 1 https://github.com/openebs/istgt.git
     echo "Clone Completed"
 fi
 
 cd istgt
-if [ ! -z "${GITHUB_USER_NAME}" ] && [ ! -z "${GITHUB_API_KEY}" ] && [ ! -z "${TRAVIS_TAG}" ];
+
+#Checkout the correct istgt code base for compilation
+# - Release Tag
+# - Master branch  - will use branch - replication
+# - Non-master branch - checkout with branch name or 
+#   will fallback to default branch (replication)
+if [ ! -z "${TRAVIS_TAG}" ];
 then
+    echo "checkout code from release tag: ${TRAVIS_TAG}"
     git checkout ${TRAVIS_TAG}
+elif [ ! -z "${TRAVIS_BRANCH}" ];
+then
+    if [ $TRAVIS_BRANCH = "master" ];
+    then
+        echo "checkout code from branch: ${ISTGT_MASTER}"
+        #This repo is setup with default ISTGT_MASTER, no
+        # need to checkout again
+    else
+        echo "checkout code from branch: ${TRAVIS_BRANCH}"
+        git checkout ${TRAVIS_BRANCH}
+        #This repo is setup with default ISTGT_MASTER,
+        # on error, it will use the default
+    fi;
 fi;
+
 sh autogen.sh
 ./configure --enable-replication
 make clean

--- a/image-tag
+++ b/image-tag
@@ -1,9 +1,19 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # Specify the date of build
 BUILD_DATE=$(date +'%Y%m%d%H%M%S')
-# Specify the build tag
-RELEASE_TAG="dev"
-VERSION="${RELEASE_TAG}-${BUILD_DATE}"
-IMAGE_TAG=${VERSION}
+GIT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
+
+# There can be multiple active branches. 
+# Prefix the ci tags with branch name, except when building from master.
+MASTER="master"
+if [ "$GIT_BRANCH" == "$MASTER" ];
+then
+  CI_IMAGE_TAG="ci"
+else
+  CI_IMAGE_TAG="$GIT_BRANCH-ci"
+fi
+export CI_IMAGE_TAG
+
+IMAGE_TAG="${GIT_BRANCH}-${BUILD_DATE}"
 export IMAGE_TAG

--- a/push-baseimage
+++ b/push-baseimage
@@ -8,7 +8,10 @@ if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ];
 then
   sudo docker login -u "${DNAME}" -p "${DPASS}";
   # Push image to docker hub
-  sudo docker push openebs/cstor-base:ci ;
+  # sudo docker push openebs/cstor-base:ci ;
+  sudo docker tag ${IMAGEID} openebs/cstor-base:${CI_IMAGE_TAG}
+  sudo docker push openebs/cstor-base:${CI_IMAGE_TAG};
+
   if [ ! -z "${TRAVIS_TAG}" ] ;
   then
     # Push with different tags if tagged as a release

--- a/push-basetestimage
+++ b/push-basetestimage
@@ -8,7 +8,9 @@ if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ];
 then
   sudo docker login -u "${DNAME}" -p "${DPASS}";
   # Push image to docker hub
-  sudo docker push openebs/cstor-test:ci ;
+  # sudo docker push openebs/cstor-test:ci ;
+  sudo docker tag ${IMAGEID} openebs/cstor-test:${CI_IMAGE_TAG}
+  sudo docker push openebs/cstor-test:${CI_IMAGE_TAG};
   if [ ! -z "${TRAVIS_TAG}" ] ;
   then
     # Push with different tags if tagged as a release

--- a/push-istgtimage
+++ b/push-istgtimage
@@ -9,7 +9,9 @@ if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ];
 then
   sudo docker login -u "${DNAME}" -p "${DPASS}";
   # Push image to docker hub
-  sudo docker push openebs/cstor-istgt:ci ;
+  # sudo docker push openebs/cstor-istgt:ci ;
+  sudo docker tag ${IMAGEID} openebs/cstor-istgt:${CI_IMAGE_TAG}
+  sudo docker push openebs/cstor-istgt:${CI_IMAGE_TAG};
   if [ ! -z "${TRAVIS_TAG}" ] ;
   then
     # Push with different tags if tagged as a release

--- a/push-poolimage
+++ b/push-poolimage
@@ -8,7 +8,9 @@ if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ];
 then
   sudo docker login -u "${DNAME}" -p "${DPASS}";
   # Push image to docker hub
-  sudo docker push openebs/cstor-pool:ci ;
+  # sudo docker push openebs/cstor-pool:ci ;
+  sudo docker tag ${IMAGEID} openebs/cstor-pool:${CI_IMAGE_TAG}
+  sudo docker push openebs/cstor-pool:${CI_IMAGE_TAG};
   if [ ! -z "${TRAVIS_TAG}" ] ;
   then
     # Push with different tags if tagged as a release


### PR DESCRIPTION
We now have development that can go on in parallel on master as well as in released branches (for bugfix or dot releases).  There has to be a way to differentiate between the docker images build from master as well as non-master branches. 

The master branches will continue to use non-prefixed builds like "ci". However the builds generated from non-master branch will get a prefix like "<branch>-ci"

Signed-off-by: kmova <kiran.mova@openebs.io>