### PR TITLE
[TA2512] Add libjson-c support in cstor build for zfs

### DIFF
--- a/Dockerfile.Baseimage
+++ b/Dockerfile.Baseimage
@@ -8,7 +8,7 @@ FROM ubuntu:16.04
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \ 
     apt-get update && apt-get install -y \
-    libaio1 libaio-dev \
+    libaio1 libaio-dev libjson-c-dev	\
     libkqueue-dev libssl1.0.0 rsyslog net-tools gdb apt-utils \
     sed libjemalloc-dev openssh-server
 


### PR DESCRIPTION
Changes:
- Added `libjson-c` library support in for zfs docker image (needed for snapshot list support)

Signed-off-by: mayank <mayank.patel@cloudbyte.com>