### PR TITLE
Fix issues with shell scripts

### DIFF
--- a/entrypoint-basetest.sh
+++ b/entrypoint-basetest.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -ex
 

--- a/entrypoint-istgtimage.sh
+++ b/entrypoint-istgtimage.sh
@@ -1,13 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -o errexit
 trap 'call_exit $LINE_NO' EXIT
 
-call_exit()
-{
-echo "at call_exit.."     
-echo  "exit code:" $?
-echo "reference: "  $0 
+call_exit() {
+    echo "at call_exit.."     
+    echo "exit code:  $?" 
+    echo "reference:  $0"   
 }
 
 if [ ! -f "/usr/local/etc/istgt/istgt.conf" ];then

--- a/entrypoint-poolimage.sh
+++ b/entrypoint-poolimage.sh
@@ -1,13 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -o errexit
 trap 'call_exit $LINE_NO' EXIT
 
-call_exit()
-{
-echo "at call_exit.."     
-echo  "exit code:" $?
-echo "reference: "  $0 
+call_exit() {
+    echo "at call_exit.."
+    echo "exit code: $?"
+    echo "reference: $0"
 }
 
 service ssh start
@@ -18,4 +17,4 @@ fi
 echo "sleeping for 2 sec"
 sleep 2
 export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
-exec /usr/local/bin/zrepl -l $LOGLEVEL
+exec /usr/local/bin/zrepl -l "$LOGLEVEL"

--- a/push
+++ b/push
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -e
 
 if [ -z ${IMAGE_REPO} ];
@@ -16,7 +17,7 @@ BUILD_DATE=$(date +'%Y%m%d%H%M%S')
 CURRENT_BRANCH=""
 if [ -z ${TRAVIS_BRANCH} ];
 then
-  CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
+  CURRENT_BRANCH=$( git rev-parse --abbrev-ref HEAD 2> /dev/null)
 else
   CURRENT_BRANCH=${TRAVIS_BRANCH}
 fi


### PR DESCRIPTION
The following shell scripts required some tweaking:  
```
entrypoint-basetest.sh
entrypoint-istgtimage.sh
entrypoint-poolimage.sh
push
```

Fixes:  
1. Quoting variable substitutions.
2. Use `#!/usr/bin/env bash` over `#!/bin/sh`.
3. Follow indentation guidelines.
4. Remove trailing whitespaces.
5. Use `git rev-parse` over `git branch` to fetch current branch details, `rev-parse` may have a more stable cli.